### PR TITLE
Set default locale and enable locale selection for users (I18n)

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 class ApplicationController < ActionController::Base
+  before_action :set_i18n_locale_from_params
   before_action :authorize
   allow_browser versions: :modern
 
@@ -13,5 +14,17 @@ class ApplicationController < ActionController::Base
     return if current_user
 
     redirect_to login_url, notice: "Please log in"
+  end
+
+  def set_i18n_locale_from_params
+    return unless params[:locale]
+
+    if I18n.available_locales.map(&:to_s).include?(params[:locale])
+      I18n.locale = params[:locale]
+    else
+      flash.now[:notice] =
+        "#{params[:locale]} translation not available"
+      logger.error flash.now[:notice]
+    end
   end
 end

--- a/app/controllers/orders_controller.rb
+++ b/app/controllers/orders_controller.rb
@@ -33,7 +33,7 @@ class OrdersController < ApplicationController
         Cart.destroy(session[:cart_id])
         session[:cart_id] = nil
         ChargeOrderJob.perform_later(@order, pay_type_params.to_h)
-        format.html { redirect_to store_index_url, notice: "Thank you for your order." }
+        format.html { redirect_to store_index_url(locale: I18n.locale), notice: I18n.t(".thanks") }
         format.json { render :show, status: :created, location: @order }
       else
         format.html { render :new, status: :unprocessable_entity }

--- a/app/controllers/store_controller.rb
+++ b/app/controllers/store_controller.rb
@@ -6,8 +6,11 @@ class StoreController < ApplicationController
   before_action :set_cart
 
   def index
-    update_counter
-    @products = Product.order(:title)
+    if params[:set_locale]
+      redirect_to store_index_url(locale: params[:set_locale])
+    else
+      @products = Product.order(:title)
+    end
   end
 
   private

--- a/app/javascript/controllers/locale_controller.js
+++ b/app/javascript/controllers/locale_controller.js
@@ -1,0 +1,10 @@
+import { Controller } from "@hotwired/stimulus";
+
+// Connects to data-controller="locale"
+export default class extends Controller {
+    static targets = ["submit"];
+
+    initialize() {
+        this.submitTarget.style.display = "none";
+    }
+}

--- a/app/views/carts/_cart.html.erb
+++ b/app/views/carts/_cart.html.erb
@@ -1,5 +1,5 @@
 <div id="<%= dom_id cart %>">
-	<h2 class="font-bold text-lg mb-3">Your Cart</h2>
+	<h2 class="font-bold text-lg mb-3"><%= t('.title') %></h2>
 	<table class="table-auto">
 		<%= render cart.line_items %>
 		<tfoot>
@@ -11,9 +11,9 @@
 		</tfoot>
 	</table>
 	<div class="flex mt-1 flex-col md:flex-row">
-		<%= button_to 'Empty Cart', cart, method: :delete,
+		<%= button_to t('.empty'), cart, method: :delete,
       class: 'ml-4 flex-grow rounded-lg py-1 px-2 text-white bg-green-600' %>
-		<%= button_to 'Checkout', new_order_path, method: :get,
+		<%= button_to t('.checkout'), new_order_path(locale: I18n.locale), method: :get,
       class: 'ml-4 flex-grow rounded-lg py-1 px-2 text-black bg-green-200 mt-2 md:mt-0' %>
 	</div>
 </div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -2,33 +2,38 @@
 <html>
 	<head>
 		<title>Pragprog Books Online Store</title>
-		<meta name="viewport" content="width=device-width,initial-scale=1">
-		<meta name="apple-mobile-web-app-capable" content="yes">
-		<%= csrf_meta_tags %>
-		<%= csp_meta_tag %>
-		<%= yield :head %>
-		<link rel="manifest" href="/manifest.json">
-		<link rel="icon" href="/icon.png" type="image/png">
-		<link rel="icon" href="/icon.svg" type="image/svg+xml">
-		<link rel="apple-touch-icon" href="/icon.png">
-		<%= stylesheet_link_tag "tailwind", "inter-font", "data-turbo-track": "reload" %>
-		<%= stylesheet_link_tag "application", "data-turbo-track": "reload" %>
-		<%= javascript_importmap_tags %>
+    <meta name="viewport" content="width=device-width,initial-scale=1"> 
+    <%= csrf_meta_tags %>
+    <%= csp_meta_tag %>
+    <%= stylesheet_link_tag "inter-font", "data-turbo-track": "reload" %>
+    <%= stylesheet_link_tag "tailwind", "data-turbo-track": "reload" %>
+    <%= stylesheet_link_tag "application", "data-turbo-track": "reload" %>
+    <%= javascript_importmap_tags %>
 	</head>
 	<body class="flex flex-col min-h-screen">
-		<header class="bg-green-700">
-			<%= image_tag 'logos/logo.svg', alt: 'The Pragmatic Bookshelf' %>
-			<h1><%= @page_title %></h1>
+		<header class="bg-green-700 flex justify-between items-center">
+      <div class="flex items-center">
+        <%= image_tag 'logos/logo.svg', alt: 'The Pragmatic Bookshelf' %>
+        <h1><%= @page_title %></h1>
+      </div>
+      <aside data-controller="locale">
+        <%= form_tag store_index_path, class: 'locale' do %> 
+          <%= select_tag 'set_locale',
+            options_for_select(LANGUAGES, I18n.locale.to_s),
+            onchange: 'this.form.submit()' %>
+          <%= submit_tag 'submit', data: {'locale-target' => 'submit'} %>
+        <% end %>
+      </aside>
 		</header>
 		<section class="flex flex-grow">
 			<nav class="bg-green-900 p-6 flex-shrink-0">
 				<%= render partial: 'layouts/cart', locals: {cart: @cart } %>
 				<ul class="text-gray-300 leading-8">
-					<li><a href="/">Home</a></li>
-					<li><a href="/questions">Questions</a></li>
-					<li><a href="/news">News</a></li>
-					<li><a href="/contact">Contact</a></li>
-				</ul>
+          <li><a href="/"><%= t('.home') %></a></li>
+          <li><a href="/questions"><%= t('.questions') %></a></li>
+          <li><a href="/news"><%= t('.news') %></a></li>
+          <li><a href="/contact"><%= t('.contact') %></a></li>
+        </ul>
 
         <% if session[:user_id] %>
           <hr class="my-2">

--- a/app/views/orders/_cc.html.erb
+++ b/app/views/orders/_cc.html.erb
@@ -1,9 +1,9 @@
 <fieldset data-payment-target="additionalFields" data-type="Credit card">
 	<div class="my-5">
-		<%= form.label :credit_card_number %>
+		<%= form.label t('.cc_number') %>
 		<%= form.password_field :credit_card_number, class: "input-field" %> </div>
 	<div class="my-5">
-		<%= form.label :expiration_date %>
+		<%= form.label t('.expiration_date') %>
 		<%= form.text_field :expiration_date, class: "input-field",
         size:9, placeholder: "e.g. 03/22" %>
 	</div>

--- a/app/views/orders/_check.html.erb
+++ b/app/views/orders/_check.html.erb
@@ -1,9 +1,9 @@
 <fieldset data-payment-target="additionalFields" data-type="Check">
 	<div class="my-5">
-		<%= form.label :routing_number %>
+		<%= form.label t('.routing_number') %>
 		<%= form.text_field :routing_number, class: "input-field" %> </div>
 	<div class="my-5">
-		<%= form.label :account_number %>
+		<%= form.label t('.account_number') %>
 		<%= form.password_field :account_number, class: "input-field" %>
 	</div>
 </fieldset>

--- a/app/views/orders/_form.html.erb
+++ b/app/views/orders/_form.html.erb
@@ -1,31 +1,34 @@
 <%= form_with(model: order, class: "contents") do |form| %>
 	<% if order.errors.any? %>
 		<div id="error_explanation" class="bg-red-50 text-red-500 px-3 py-2 font-medium rounded-lg mt-3">
-			<h2><%= pluralize(order.errors.count, "error") %> prohibited this order from being saved:</h2>
+			<h2><%=raw t('errors.template.header', count: @order.errors.count,
+        model: t('activerecord.models.order')) %>.</h2>
+      <p><%= t('errors.template.body') %></p>
 			<ul>
 				<% order.errors.each do |error| %>
-					<li><%= error.full_message %></li>
+					<li><%=raw error.full_message %></li>
 				<% end %>
 			</ul>
 		</div>
 	<% end %>
 	<div class="my-5">
-		<%= form.label :name %>
+		<%= form.label :name, t('.name') %>
 		<%= form.text_field :name, class: "input-field" %>
 	</div>
 	<div class="my-5">
-		<%= form.label :address %>
+		<%= form.label :address, t('.address_html') %>
 		<%= form.text_area :address, rows: 4, class: "input-field" %>
 	</div>
 	<div class="my-5">
-		<%= form.label :email %>
+		<%= form.label :email, t('.email') %>
 		<%= form.text_field :email, class: "input-field" %>
 	</div>
 	<div data-controller="payment">
 		<div class="my-5">
-			<%= form.label :pay_type %>
-			<%= form.select :pay_type, Order.pay_types.keys,
-				{ prompt: 'Select a payment method' },
+			<%= form.label :pay_type, t('.pay_type') %>
+			<%= form.select :pay_type,
+        Order.pay_types.keys.map {|key| [t(".pay_types.#{key}"), key] },
+				{ prompt: t('.pay_prompt_html') },
 				'data-payment-target' => 'selection',
 				'data-action' => 'payment#showAdditionalFields',
 				class: "input-field" %>
@@ -35,7 +38,7 @@
 		<%= render partial: 'po', locals: {form: form} %>
 	</div>
 	<div class="inline">
-		<%= form.submit 'Place Order', class: "rounded-lg py-3 px-5
+		<%= form.submit t('.submit'), class: "rounded-lg py-3 px-5
 			bg-green-200 text-black inline-block font-medium cursor-pointer" %>
 	</div>
 <% end %>

--- a/app/views/orders/_po.html.erb
+++ b/app/views/orders/_po.html.erb
@@ -1,6 +1,6 @@
 <fieldset data-payment-target="additionalFields" data-type="Purchase order">
 	<div class="my-5">
-		<%= form.label :po_number %>
+		<%= form.label t('.po_number') %>
 		<%= form.number_field :po_number, class: "input-field" %>
 	</div>
 </fieldset>

--- a/app/views/orders/new.html.erb
+++ b/app/views/orders/new.html.erb
@@ -1,5 +1,6 @@
 <div class="mx-auto md:w-2/3 w-full">
-	<h1 class="font-bold text-4xl">New order</h1>
+	<h1 class="font-bold text-4xl"><%= t('.legend') %></h1>
+
 	<%= render "form", order: @order %>
 	<%= link_to "Back to orders", orders_path, class: "ml-2 rounded-lg py-3 px-5 bg-gray-100 inline-block font-medium" %>
 </div>

--- a/app/views/store/_product.html.erb
+++ b/app/views/store/_product.html.erb
@@ -8,7 +8,7 @@
 			</p>
 			<div class="mt-3">
 				<%= number_to_currency(product.price) %>
-				<%= button_to 'Add to Cart',
+				<%= button_to t('.add_html'),
                     line_items_path(product_id: product),
                     form_class: 'inline',
                     class: 'ml-4 rounded-lg py-1 px-2

--- a/app/views/store/index.html.erb
+++ b/app/views/store/index.html.erb
@@ -1,7 +1,7 @@
 <div class="w-full">
 	<%= render 'notice' %>
 	<h1 class="font-bold text-xl mb-6 pb-2 border-b-2">
-		Your Pragmatic Catalog
+		<%= t('.title_html') %>
 	</h1>
 	<%= turbo_stream_from 'products' %>
 	<ul>

--- a/config/initializers/i18n.rb
+++ b/config/initializers/i18n.rb
@@ -1,0 +1,7 @@
+#encoding: utf-8
+
+I18n.default_locale = :en
+
+LANGUAGES = [
+  ['English', 'en'], ["Українська".html_safe, 'uk']
+]

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,31 +1,60 @@
-# Files in the config/locales directory are used for internationalization and
-# are automatically loaded by Rails. If you want to use locales other than
-# English, add the necessary files in this directory.
-#
-# To use the locales, use `I18n.t`:
-#
-#     I18n.t "hello"
-#
-# In views, this is aliased to just `t`:
-#
-#     <%= t("hello") %>
-#
-# To use a different locale, set it with `I18n.locale`:
-#
-#     I18n.locale = :es
-#
-# This would use the information in config/locales/es.yml.
-#
-# To learn more about the API, please read the Rails Internationalization guide
-# at https://guides.rubyonrails.org/i18n.html.
-#
-# Be aware that YAML interprets the following case-insensitive strings as
-# booleans: `true`, `false`, `on`, `off`, `yes`, `no`. Therefore, these strings
-# must be quoted to be interpreted as strings. For example:
-#
-#     en:
-#       "yes": yup
-#       enabled: "ON"
-
 en:
-  hello: "Hello world"
+    layouts:
+        application:
+            title: "The Pragmatic Bookshelf"
+            home: "Home"
+            questions: "Questions"
+            news: "News"
+            contact: "Contact"
+    store:
+        index:
+            title_html: "Your Pragmatic Catalog"
+        product:
+            add_html: "Add to Cart"
+    carts:
+        cart:
+            title: "Your Cart"
+            empty: "Empty cart"
+            checkout: "Checkout"
+    orders:
+        new:
+            legend: "Please Enter Your Details"
+        form:
+            name: "Name"
+            address_html: "Address"
+            email: "E-mail"
+            pay_type: "Pay with"
+            pay_prompt_html: "Select a payment method"
+            submit: "Place Order"
+            pay_types:
+                "Check": "Check"
+                "Credit card": "Credit Card"
+                "Purchase order": "Purchase Order"
+        check:
+            routing_number: "Routing #"
+            account_number: "Account #"
+        cc:
+            cc_number: "CC #"
+            expiration_date: "Expiry"
+        po:
+            po_number: "PO #"
+    activerecord:
+        errors:
+            messages:
+                inclusion: "is not included in the list"
+                blank: "can't be blank"
+        models:
+            order: "order"
+        attributes:
+            order:
+                address: "Address"
+                name: "Name"
+                email: "E-mail"
+                pay_type: "Pay type"
+    errors:
+        template:
+            body: "There are problems with the following fields:"
+            header:
+                one: "1 error prohibited this %{model} from being saved"
+                other: "%{count} errors prohibited this %{model} from being saved"
+    thanks: "Thank you for your order"

--- a/config/locales/uk.yml
+++ b/config/locales/uk.yml
@@ -1,0 +1,60 @@
+uk:
+    layouts:
+        application:
+            title: "Практична книжкова полиця"
+            home: "Головна"
+            questions: "Питання"
+            news: "Новини"
+            contact: "Контакти"
+    store:
+        index:
+            title_html: "Ваш Практичний Каталог"
+        product:
+            add_html: "Додати до кошика"
+    carts:
+        cart:
+            title: "Ваш кошик"
+            empty: "Очистити"
+            checkout: "Оформити"
+    orders:
+        new:
+            legend: "Будь ласка, введіть свої дані"
+        form:
+            name: "Ім'я"
+            address_html: "Адреса"
+            email: "E-mail"
+            pay_type: "Оплатити за допомогою"
+            pay_prompt_html: "Оберіть спосіб оплати"
+            submit: "Підтвердити замовлення"
+            pay_types:
+                "Check": "Чек"
+                "Credit card": "Кредитна картка"
+                "Purchase order": "Закупівельний ордер"
+        check:
+            routing_number: "Номер маршруту"
+            account_number: "Номер рахунку"
+        cc:
+            cc_number: "Номер картки"
+            expiration_date: "Термін дії"
+        po:
+            po_number: "Номер PO #"
+    activerecord:
+        errors:
+            messages:
+                inclusion: "не входить до списку"
+                blank: "не може бути порожнім"
+        models:
+            order: "замовлення"
+        attributes:
+            order:
+                address: "Адреса"
+                name: "Ім'я"
+                email: "Електронна пошта"
+                pay_type: "Спосіб оплати"
+    errors:
+        template:
+            body: "Є проблеми з наступними полями:"
+            header:
+                one: "1 помилка завадила збереженню цього %{model}"
+                other: "%{count} помилок завадили збереженню цього %{model}"
+    thanks: "Дякуємо за ваше замовлення"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,29 +1,25 @@
 # frozen_string_literal: true
 
 Rails.application.routes.draw do
-  root "store#index", as: "store_index"
-
   get "admin" => "admin#index"
+
   controller :sessions do
     get "login" => :new
     post "login" => :create
     delete "logout" => :destroy
   end
+
+  get "sessions/create"
+  get "sessions/destroy"
   resources :users
-  resources :line_items
-  resources :carts
-  resources :products
-  resources :orders
-  # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
+  resources :products do
+    get :who_bought, on: :member
+  end
 
-  # Reveal health status on /up that returns 200 if the app boots with no exceptions, otherwise 500.
-  # Can be used by load balancers and uptime monitors to verify that the app is live.
-  get "up" => "rails/health#show", as: :rails_health_check
-
-  # Render dynamic PWA files from app/views/pwa/*
-  get "service-worker" => "rails/pwa#service_worker", as: :pwa_service_worker
-  get "manifest" => "rails/pwa#manifest", as: :pwa_manifest
-
-  # Defines the root path route ("/")
-  # root "posts#index"
+  scope "(:locale)" do
+    resources :orders
+    resources :line_items
+    resources :carts
+    root "store#index", as: "store_index", via: :all
+  end
 end

--- a/spec/controllers/orders_controller_spec.rb
+++ b/spec/controllers/orders_controller_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe OrdersController, type: :controller do
 
       it "redirects to the created order" do
         post :create, params: { order: valid_attributes }
-        expect(response).to redirect_to(store_index_url)
+        expect(response).to redirect_to(store_index_url(locale: "en"))
       end
     end
   end


### PR DESCRIPTION
- Set the default locale for the application.
- Created translation files for text fields, currency amounts, errors, and model names.
- Modified layouts and views to use the I18n module with the `t` helper for translating textual interface elements.